### PR TITLE
Adds `createSettingsModel()`.

### DIFF
--- a/src/ImageOptim.php
+++ b/src/ImageOptim.php
@@ -70,4 +70,15 @@ class ImageOptim extends Plugin
             __METHOD__
         );
     }
+
+    // Protected Methods
+    // =========================================================================
+
+    /**
+     * @inheritdoc
+     */
+    protected function createSettingsModel()
+    {
+        return new \nystudio107\imageoptim\models\Settings();
+    }
 }


### PR DESCRIPTION
This allows overriding of the default plugin settings by placing a
`imageoptim.php` file in the `craft/config` folder. An error would be
thrown before. Fixes #3.